### PR TITLE
Fix: correct labels file extension from .json to .yml in setup instru…

### DIFF
--- a/setup/start.md
+++ b/setup/start.md
@@ -4,4 +4,4 @@ This is for the folks who set up the final feature repo.
 
 ## Labels
 
-Create the following labels in github. Use the .github/labels.json file
+Create the following labels in github. Use the .github/labels.yml file


### PR DESCRIPTION
## Issue
The setup instructions in `setup/start.md` incorrectly reference `.github/labels.json`, but the actual file is named `labels.yml`.

## Changes
- Updated the file reference from `.github/labels.json` to `.github/labels.yml` in the Labels section of the setup instructions

## Verification
The actual labels file exists at `.github/labels.yml` as confirmed by inspecting the repository structure.